### PR TITLE
Fix Pages deploy evidence with CI checkouts

### DIFF
--- a/cmd/vo-dev/src/first_party.rs
+++ b/cmd/vo-dev/src/first_party.rs
@@ -216,6 +216,27 @@ pub(crate) fn ci_checkout_for(root: &Path, repo: &str) -> Result<CiCheckout> {
     })
 }
 
+pub(crate) fn ci_checkout_untracked_prefixes(root: &Path) -> Result<Vec<String>> {
+    if !root.join("eng/project.toml").exists() {
+        return Ok(Vec::new());
+    }
+    let project = load_project(root)?;
+    let mut prefixes = Vec::new();
+    for entry in project
+        .first_party
+        .iter()
+        .chain(project.external_project.iter())
+    {
+        if entry.ci_checkout == Some(true) {
+            let prefix = format!("ci_modules/{}/", entry.name);
+            prefixes.push(prefix);
+        }
+    }
+    prefixes.sort();
+    prefixes.dedup();
+    Ok(prefixes)
+}
+
 pub(crate) fn project_repo_path(root: &Path, repo: &str) -> Result<PathBuf> {
     let project = load_project(root)?;
     let entry = project_repo_entry(&project, repo)

--- a/cmd/vo-dev/src/task_runner.rs
+++ b/cmd/vo-dev/src/task_runner.rs
@@ -1,4 +1,5 @@
 use crate::config::{load_tasks, load_toolchains, Task};
+use crate::first_party::ci_checkout_untracked_prefixes;
 use crate::task_graph::{resolve_selector, task_map, task_tools_recursive};
 use crate::tool_lint::lint_toolchain_file;
 use crate::tool_system::check_tools;
@@ -166,6 +167,12 @@ fn ensure_no_untracked_vm_production_source(root: &Path) -> Result<()> {
         path != "lang/docs/dev/vm-production-readiness.md"
             && !path.starts_with("lang/docs/dev/vm-production-gate-evidence/")
     });
+    let ci_checkout_prefixes = ci_checkout_untracked_prefixes(root)?;
+    files.retain(|path| {
+        !ci_checkout_prefixes
+            .iter()
+            .any(|prefix| path.starts_with(prefix))
+    });
     files.sort();
     if files.is_empty() {
         return Ok(());
@@ -330,6 +337,55 @@ tier = "release"
             msg.contains(".github/workflows/production-readiness.yml"),
             "{msg}"
         );
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn vm_production_source_state_ignores_declared_ci_checkout_039() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "volang-vo-dev-source-state-ci-checkout-{stamp}-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(root.join("eng")).expect("eng dir");
+        fs::create_dir_all(root.join("lang/docs/dev")).expect("docs dir");
+        fs::write(root.join("src.vo"), "package main\nfunc main() {}\n").expect("src");
+        fs::write(
+            root.join("lang/docs/dev/vm-production-readiness.md"),
+            "# VM Production Readiness Plan\n",
+        )
+        .expect("readiness");
+        fs::write(
+            root.join("eng/project.toml"),
+            r#"version = 1
+
+[repo]
+name = "volang"
+module = "github.com/vo-lang/volang"
+
+[[first_party]]
+name = "vogui"
+repository = "vo-lang/vogui"
+ci_checkout = true
+"#,
+        )
+        .expect("project config");
+        run_git(&root, &["init", "-q"]);
+        run_git(&root, &["add", "."]);
+
+        fs::create_dir_all(root.join("ci_modules/vogui")).expect("ci checkout dir");
+        fs::write(
+            root.join("ci_modules/vogui/vo.mod"),
+            "module github.com/vo-lang/vogui\n",
+        )
+        .expect("ci checkout source");
+
+        current_vm_production_source_state_hash(&root)
+            .expect("declared CI checkout should not dirty final evidence state");
 
         fs::remove_dir_all(root).ok();
     }

--- a/lang/docs/dev/vm-production-gate-evidence/site.json
+++ b/lang/docs/dev/vm-production-gate-evidence/site.json
@@ -3,7 +3,7 @@
   "selector": "site",
   "changed": false,
   "passed": true,
-  "source_state": "vm-production-current-source:2926786af616af721c321b3c15db600c7835b176e65a195aced30fe56e26cc99",
+  "source_state": "vm-production-current-source:ab5b75990e03a59c67567e4125b665bb0666fc8fa4eaeabe60475418a243ca0e",
   "tasks": [
     "vo-web-wasm-build",
     "vogui-npm-ci",


### PR DESCRIPTION
## Summary
- Ignore declared first-party CI checkout directories when computing final gate source evidence
- Keep generic untracked source rejection intact with a focused vo-dev regression test
- Refresh site gate evidence via the declared site task

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vo-dev vm_production_source_state_ -- --nocapture
- cargo check -p vo-dev
- cargo test -p vo-dev
- cargo clippy -p vo-dev -- -D warnings
- cargo run -q -p vo-dev -- lint all
- cargo run -q -p vo-dev -- task run site
- cargo run -q -p vo-dev -- task plan pr --changed
- cargo run -q -p vo-dev -- verify plan pr

Post-merge failure addressed: main run 28319100793 / Deploy Studio to GitHub Pages failed because the declared first-party checkout under ci_modules/vogui/ was treated as an untracked source path by final evidence.