### PR TITLE
Refresh Studio audit-safe lockfile deps

### DIFF
--- a/apps/studio/package-lock.json
+++ b/apps/studio/package-lock.json
@@ -1415,9 +1415,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -1453,9 +1453,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -1473,7 +1473,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary
- refresh Studio lockfile-only dependencies within existing semver-safe ranges
- updates PostCSS and its nanoid dependency to patched releases
- leaves Vite/Svelte/Monaco breaking-change advisories for a separate migration PR

## Verification
- npm ci --cache /private/tmp/volang-npm-cache --logs-dir /private/tmp/volang-npm-logs (apps/studio)
- npm run build (apps/studio)
- git diff --check
- cargo run -q -p vo-dev -- lint all
- cargo run -q -p vo-dev -- task plan pr --changed
- cargo run -q -p vo-dev -- verify plan pr
- pre-push hook passed: lint all, d.py smoke, task/artifact/repo/release/layout/docs/examples/benchmarks lints, cargo fmt, cargo clippy, cargo check, vo-web wasm check

## Residual audit notes
- npm audit still reports Studio advisories requiring breaking changes: Vite/Svelte plugin chain, Svelte major migration, and Monaco/DOMPurify resolution. Those are intentionally not forced in this lockfile-only PR.